### PR TITLE
Fix various typos

### DIFF
--- a/p3/README.md
+++ b/p3/README.md
@@ -108,7 +108,7 @@ At this point, try running `autograde.py`. The test `math_db_grpc` should pass.
 
 ### Server
 
-Add a `MathDb` class to `server.py` that inherits from `mathdb_pb2_grpc.MathDbServicer`. This base class has the function signatures of all the methods you will need to implement. `MathDb` should override the two methods of `MathDbServicer` and use a `MathCache` to help calculate the answers.
+Add a `MathDb` class to `server.py` that inherits from `mathdb_pb2_grpc.MathDbServiceServicer`. This base class has the function signatures of all the methods you will need to implement. `MathDb` should override the two methods of `MathDbServiceServicer` and use a `MathCache` to help calculate the answers.
 
 The `error` fields should contain the empty string `""` when no exceptions occur; however, you should wrap your code in a `try/except` so that in the event of an exception, you can return an error message that can help you debug. If you did not do this, exceptions happening on the server side would not show up anywhere, making troubleshooting difficult.
 
@@ -124,7 +124,7 @@ import mathdb_pb2_grpc
 
 if __name__ == "__main__":
   server = grpc.server(futures.ThreadPoolExecutor(max_workers=4), options=(('grpc.so_reuseport', 0),))
-  mathdb_pb2_grpc.add_MathDbServicer_to_server(MathDb(), server)
+  mathdb_pb2_grpc.add_MathDbServiceServicer_to_server(MathDb(), server)
   server.add_insecure_port("[::]:5440", )
   server.start()
   server.wait_for_termination()

--- a/p3/README.md
+++ b/p3/README.md
@@ -94,7 +94,7 @@ Specify `syntax="proto3";` at the top of your file.
     - `GetResponse`: `value` (`float`) and `error` (`string`)
 3. `Add`/`Sub`/`Mult`/`Div`
     - `BinaryOpRequest`: `key_a` (`string`) and `key_b` (`string`)
-    - `BinaryOpResponse`: `value` (`string`), `cache_hit` (`bool`), and `error` (`string`)
+    - `BinaryOpResponse`: `value` (`float`), `cache_hit` (`bool`), and `error` (`string`)
 
 You can build your `.proto` with:
 

--- a/p3/autograde.py
+++ b/p3/autograde.py
@@ -30,13 +30,13 @@ def with_client():
                 return "mathdb_pb2_grpc.py not found"
 
             # pylint: disable=import-outside-toplevel,import-error,no-name-in-module
-            from mathdb_pb2_grpc import MathDbStub
+            from mathdb_pb2_grpc import MathDbServiceStub
 
             # pylint: enable=import-outside-toplevel,import-error,no-name-in-module
 
             addr = f"127.0.0.1:{PORT}"
             channel = grpc.insecure_channel(addr)
-            stub = MathDbStub(channel)
+            stub = MathDbServiceStub(channel)
             return test_func(stub)
 
         return wrapper


### PR DESCRIPTION
The datatype associated with `value` should be `float` and not `string`
We were instructed to use the service `MathDbService`, so `MathDbServiceServicer` should be referenced later on