### PR TITLE
update p7 Dockerfile & autograde

### DIFF
--- a/p7/Dockerfile
+++ b/p7/Dockerfile
@@ -8,11 +8,11 @@ ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 RUN pip3 install jupyterlab==4.0.3 pandas==2.1.1 matplotlib==3.8.0 kafka-python==2.0.2 grpcio==1.58.0 grpcio-tools==1.58.0
 
 # Kafka (see https://kafka.apache.org/quickstart, KRaft config)
-RUN wget https://downloads.apache.org/kafka/3.6.0/kafka_2.13-3.6.0.tgz && tar -xf kafka_2.13-3.6.0.tgz && rm kafka_2.13-3.6.0.tgz
+RUN wget https://downloads.apache.org/kafka/3.6.2/kafka_2.12-3.6.2.tgz && tar -xf kafka_2.12-3.6.2.tgz && rm kafka_2.12-3.6.2.tgz
 
 # from bin/kafka-storage.sh random-uuid
 ENV KAFKA_CLUSTER_ID=dCHffFWYTCKWXiesmJMN9w
 
 COPY ./files /files/
 
-CMD sh -c "cd /kafka_2.13-3.6.0 && bin/kafka-storage.sh format -t $KAFKA_CLUSTER_ID -c config/kraft/server.properties && bin/kafka-server-start.sh config/kraft/server.properties"
+CMD sh -c "cd /kafka_2.12-3.6.2 && bin/kafka-storage.sh format -t $KAFKA_CLUSTER_ID -c config/kraft/server.properties && bin/kafka-server-start.sh config/kraft/server.properties"

--- a/p7/README.md
+++ b/p7/README.md
@@ -1,5 +1,3 @@
-# DRAFT!  Don't start yet.
-
 # P7 (6% of grade): Kafka, Weather Data
 
 ## Overview
@@ -24,12 +22,6 @@ Learning objectives:
 * use manual and automatic assignment of Kafka topics and partitions
 
 Before starting, please review the [general project directions](../projects.md).
-
-## Clarifications/Correction
-
-* Nov 24: autograder.py added.
-* Nov 28: autograder bugfix: Added COPY statement to Dockerfile (required to run autograder correctly)
-* Nov 30: autograder update: Increase timeouts and delays to ensure consistent test results
 
 ## Container setup
 

--- a/p7/autograde.py
+++ b/p7/autograde.py
@@ -16,6 +16,7 @@ import subprocess
 import threading
 import time
 import json
+import argparse
 
 BROKER_URL = "localhost:9092"
 TMP_DIR = "autograder_files"
@@ -513,5 +514,6 @@ def test_plot_generation():
             return "Plot doesn't seem to be updating on re-running"
 
 if __name__ == "__main__":
-    tester_main()
+    parser = argparse.ArgumentParser()
+    tester_main(parser)
 


### PR DESCRIPTION
Two main updates:
1. Update the kafka package download link in Dockerfile.
2. Add parser to test_main()'s parameter to make autograde.py run correctly.